### PR TITLE
bug: Correcting URLs on https://rubygems.org/gems/forem_lite

### DIFF
--- a/forem_lite.gemspec
+++ b/forem_lite.gemspec
@@ -11,11 +11,11 @@ Gem::Specification.new do |s|
   s.summary = "A minimal API wrapper to retrieve Forem articles."
   s.description = s.summary
   s.metadata = {
-    "bug_tracker_uri" => "#{s.homepage}/forem_lite/issues",
+    "bug_tracker_uri" => "#{s.homepage}/issues",
     "changelog_uri" => "#{s.homepage}/blob/main/CHANGELOG.md",
-    "documentation_uri" => "#{s.homepage}/forem_lite",
-    "homepage_uri" => "#{s.homepage}/forem_lite",
-    "source_code_uri" => "#{s.homepage}/forem_lite"
+    "documentation_uri" => s.homepage,
+    "homepage_uri" => s.homepage,
+    "source_code_uri" => s.homepage
   }
 
   # Specify which files should be added to the gem when it is released.

--- a/forem_lite.gemspec
+++ b/forem_lite.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.metadata = {
     "bug_tracker_uri" => "#{s.homepage}/issues",
     "changelog_uri" => "#{s.homepage}/blob/main/CHANGELOG.md",
-    "documentation_uri" => s.homepage.to_s,
-    "homepage_uri" => s.homepage.to_s,
-    "source_code_uri" => s.homepage.to_s
+    "documentation_uri" => s.homepage,
+    "homepage_uri" => s.homepage,
+    "source_code_uri" => s.homepage
   }
 
   # Specify which files should be added to the gem when it is released.

--- a/forem_lite.gemspec
+++ b/forem_lite.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.metadata = {
     "bug_tracker_uri" => "#{s.homepage}/issues",
     "changelog_uri" => "#{s.homepage}/blob/main/CHANGELOG.md",
-    "documentation_uri" => s.homepage,
-    "homepage_uri" => s.homepage,
-    "source_code_uri" => s.homepage
+    "documentation_uri" => s.homepage.to_s,
+    "homepage_uri" => s.homepage.to_s,
+    "source_code_uri" => s.homepage.to_s
   }
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
## What is the purpose of this pull request?

Fixes the metadata links on https://rubygems.org/gems/forem_lite

![image](https://user-images.githubusercontent.com/325384/88854644-82302580-d1e9-11ea-9dc4-8ba22d8e6762.png)

## What changes did you make? (overview)

Right now they're linking to `https://github.com/andrewmcodes/forem_lite/forem_lite` instead of `https://github.com/andrewmcodes/forem_lite`. So updated the references in the gemspec.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [x] I've updated a documentation

If you liked this PR, please consider [buying me a coffee](https://www.buymeacoffee.com/MikeRogers0) ☕️